### PR TITLE
feat: use github deploy api

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This GitHub action allows you to dynamically create & deleted preview environmen
 * `humanitec-app` (required), The name of the Humanitec app
 * `action`  (required), The action to be performed (create or delete)
 * `base-env` (optional), The source environment id, "development" by default.
-* `image` (optional), The image of the workload that should be deployed, "registry.humanitec.io/${humanitec-org}/${humanitec-app}" by default.
+* `image` (optional), The image of the workload that should be deployed, "registry.humanitec.io/${humanitec-org}/${GITHUB_REPOSITORY}" by default.
 * `humanitec-api` (optional), Use a different Humanitec API host.
 * `github-token` (optional), GitHub token used for commenting inside the PR.
 
@@ -68,6 +68,16 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
+Add the following snipped after your CI step notifying Humanitec about the newly pushed image (commonly the build-push-to-humanitec step):
+
+```yaml
+- uses: humanitec/preview-envs-action@main
+  with:
+    humanitec-org: my-org
+    humanitec-app: my-app
+    action: notify
+    github-token: ${{ secrets.GITHUB_TOKEN }}
+```
 
 ## Development
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -46685,10 +46685,10 @@ const core_1 = __nccwpck_require__(2186);
 const utils_1 = __nccwpck_require__(1314);
 const humanitec_1 = __nccwpck_require__(9857);
 async function createEnvironment(input) {
-    const { orgId, appId, envId, context, octokit, humClient, branchName } = input;
+    const { orgId, appId, envId, context, octokit, humClient, branchName, environmentUrl } = input;
     const baseEnvId = (0, core_1.getInput)('base-env') || 'development';
-    const image = (0, core_1.getInput)('image') || `registry.humanitec.io/${orgId}/${appId}`;
-    const ENV_PATH = `/orgs/${orgId}/apps/${appId}/envs/${envId}`;
+    const imageName = (process.env.GITHUB_REPOSITORY || '').replace(/.*\//, '');
+    const image = (0, core_1.getInput)('image') || `registry.humanitec.io/${orgId}/${imageName}`;
     const baseEnvRes = await humClient.environmentApi.orgsOrgIdAppsAppIdEnvsEnvIdGet(orgId, appId, baseEnvId);
     if (baseEnvRes.status != 200) {
         throw new Error(`Unexpected response fetching env: ${baseEnvRes.status}, ${baseEnvRes.data}`);
@@ -46706,21 +46706,69 @@ async function createEnvironment(input) {
     if (createEnvRes.status != 201) {
         throw new Error(`Unexpected response creating env: ${baseEnvRes.status}, ${baseEnvRes.data}`);
     }
+    console.log(`Created environment: ${envId}, ${environmentUrl}`);
+    const matchRef = `refs/heads/${branchName}`;
     const createRuleRes = await humClient.automationRuleApi.orgsOrgIdAppsAppIdEnvsEnvIdRulesPost(orgId, appId, envId, {
         active: true,
         artefacts_filter: [image],
         type: 'update',
-        match_ref: `refs/heads/${branchName}`,
+        match_ref: matchRef,
     });
     if (createRuleRes.status != 201) {
         throw new Error(`Unexpected response creating rule: ${baseEnvRes.status}, ${baseEnvRes.data}`);
     }
+    console.log(`Created auto-deployment rule for ${matchRef} and image ${image}`);
     if (octokit) {
-        await octokit.rest.issues.createComment({
-            issue_number: context.issue.number,
+        const deployment = await octokit.rest.repos.createDeployment({
             owner: context.repo.owner,
             repo: context.repo.repo,
-            body: `Created environment in Humanitec: https://app.humanitec.io${ENV_PATH}`,
+            ref: branchName,
+            auto_merge: false,
+            environment: envId,
+            transient_environment: true,
+            required_contexts: [],
+        });
+        if (!('id' in deployment.data)) {
+            throw new Error(`Creating deployment failed ${deployment.data.message}`);
+        }
+        const deploymentId = deployment.data.id;
+        console.log(`Created github deployment ${deploymentId}`);
+        await octokit.rest.repos.createDeploymentStatus({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            deployment_id: deploymentId,
+            ref: branchName,
+            auto_merge: false,
+            state: 'pending',
+            environment_url: environmentUrl,
+        });
+    }
+}
+async function findLatestDeployment(octokit, envId) {
+    const deployments = await octokit.rest.repos.listDeployments({
+        owner: github_1.context.repo.owner,
+        repo: github_1.context.repo.repo,
+        environment: envId,
+    });
+    if (deployments.data.length === 0) {
+        return;
+    }
+    return deployments.data[0];
+}
+async function notifyDeploy(input) {
+    const { envId, context, octokit, environmentUrl } = input;
+    if (octokit) {
+        const latestDeployment = await findLatestDeployment(octokit, envId);
+        if (!latestDeployment) {
+            console.log('No deployment found');
+            return;
+        }
+        await octokit.rest.repos.createDeploymentStatus({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            deployment_id: latestDeployment.id,
+            state: 'success',
+            environment_url: environmentUrl,
         });
     }
 }
@@ -46730,12 +46778,18 @@ async function deleteEnvironment(input) {
     if (delEnvRes.status != 204 && delEnvRes.status != 404) {
         throw new Error(`Unexpected response creating rule: ${delEnvRes.status}, ${delEnvRes.data}`);
     }
+    console.log(`Deleted environment: ${envId}`);
     if (octokit) {
-        await octokit.rest.issues.createComment({
-            issue_number: context.issue.number,
+        const latestDeployment = await findLatestDeployment(octokit, envId);
+        if (!latestDeployment) {
+            console.log('No deployment found');
+            return;
+        }
+        await octokit.rest.repos.createDeploymentStatus({
             owner: context.repo.owner,
             repo: context.repo.repo,
-            body: `Preview environment deleted.`,
+            deployment_id: latestDeployment.id,
+            state: 'inactive',
         });
     }
 }
@@ -46743,23 +46797,28 @@ async function deleteEnvironment(input) {
  * Performs the GitHub action.
  */
 async function runAction() {
-    const token = (0, core_1.getInput)('humanitec-token', { required: true });
     const orgId = (0, core_1.getInput)('humanitec-org', { required: true });
     const appId = (0, core_1.getInput)('humanitec-app', { required: true });
-    const apiHost = (0, core_1.getInput)('humanitec-api') || 'api.humanitec.io';
     const action = (0, core_1.getInput)('action', { required: true });
     const ghToken = (0, core_1.getInput)('github-token');
     let octokit;
     if (ghToken) {
         octokit = (0, github_1.getOctokit)(ghToken);
     }
-    const branchName = process.env.GITHUB_HEAD_REF;
+    const branchName = process.env.GITHUB_HEAD_REF || process.env.GITHUB_REF_NAME;
     if (!branchName) {
         throw new Error('No branch name found');
     }
     const envId = (0, utils_1.branchNameToEnvId)('dev', branchName);
+    const envPath = `/orgs/${orgId}/apps/${appId}/envs/${envId}`;
+    const environmentUrl = `https://app.humanitec.io${envPath}`;
+    if (action == 'notify') {
+        return notifyDeploy({ orgId, appId, envId, context: github_1.context, octokit, environmentUrl });
+    }
+    const token = (0, core_1.getInput)('humanitec-token', { required: true });
+    const apiHost = (0, core_1.getInput)('humanitec-api') || 'api.humanitec.io';
     const humClient = (0, humanitec_1.createApiClient)(apiHost, token);
-    const input = { orgId, appId, envId, context: github_1.context, octokit, humClient, branchName };
+    const input = { orgId, appId, envId, context: github_1.context, octokit, humClient, branchName, environmentUrl };
     if (action == 'create') {
         return createEnvironment(input);
     }

--- a/src/action.test.ts
+++ b/src/action.test.ts
@@ -42,6 +42,10 @@ describe('action', () => {
       await runAction();
       expect(process.exitCode).toBeFalsy();
 
+      setInput('action', 'notify');
+      await runAction();
+      expect(process.exitCode).toBeFalsy();
+
       setInput('action', 'delete');
       await runAction();
       expect(process.exitCode).toBeFalsy();


### PR DESCRIPTION
Modified to the use the github deployment api, instead of commenting on each PR.

This now looks like the following (the environment name is clickable and links to the Humanitec UI, same as the View Deployment button):

Open:
<img width="714" alt="image" src="https://user-images.githubusercontent.com/864578/211676637-b897d0e6-e1ed-461a-a156-f663729325f6.png">

After image push:
<img width="953" alt="image" src="https://user-images.githubusercontent.com/864578/211676401-606fc86f-d7dd-4739-aacb-91b7d8dbc3e2.png">

Close:
<img width="875" alt="image" src="https://user-images.githubusercontent.com/864578/211676537-c3c0b4e7-56cd-4011-9ea6-e04e6eb35d77.png">

For the "ready" step to work another integration action is required to notify this action that the build finished and has been pushed.