### PR TITLE
fix: branch naming

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -46826,13 +46826,25 @@ var __importStar = (this && this.__importStar) || function (mod) {
     __setModuleDefault(result, mod);
     return result;
 };
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 const core = __importStar(__nccwpck_require__(2186));
 const action_1 = __nccwpck_require__(7672);
+const axios_1 = __importDefault(__nccwpck_require__(8757));
 (0, action_1.runAction)().catch((e) => {
     core.error('Action failed');
-    core.error(`${e.name} ${e.message}`);
     core.setFailed(`${e.name} ${e.message}`);
+    if (axios_1.default.isAxiosError(e)) {
+        if (e.config) {
+            core.error(`method: ${e.config.method}`);
+            core.error(`request: ${e.config.url}`);
+        }
+        if (e.response) {
+            core.error(`response: ${JSON.stringify(e.response.data)}`);
+        }
+    }
 });
 
 
@@ -46845,10 +46857,13 @@ const action_1 = __nccwpck_require__(7672);
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.branchNameToEnvId = void 0;
+const ENV_ID_LIMIT = 20; // Only 20 chars are supported
 const branchNameToEnvId = (prefix, branchName) => {
     branchName = branchName.replace(/[^a-z0-9-]+/g, '-'); // Remove unsupported chars
     branchName = branchName.replace(/^-+/, '').replace(/-+$/, ''); // Remove leading and trailing hyphens
-    return `${prefix}-${branchName}`.substring(0, 20); // Only 20 chars are supported
+    const idLimit = ENV_ID_LIMIT - `${prefix}-`.length;
+    // Return last as often common prefixes like "feat" or "dependabot" are used.
+    return `${prefix}-${branchName.slice(-idLimit)}`;
 };
 exports.branchNameToEnvId = branchNameToEnvId;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,18 @@
 import * as core from '@actions/core';
 import {runAction} from './action';
+import axios from 'axios';
 
 runAction().catch((e) => {
   core.error('Action failed');
-  core.error(`${e.name} ${e.message}`);
+
   core.setFailed(`${e.name} ${e.message}`);
+  if (axios.isAxiosError(e)) {
+    if (e.config) {
+      core.error(`method: ${e.config.method}`);
+      core.error(`request: ${e.config.url}`);
+    }
+    if (e.response) {
+      core.error(`response: ${JSON.stringify(e.response.data)}`);
+    }
+  }
 });

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -6,7 +6,7 @@ describe('utils', () => {
     const testCases = [
       {name: 'basic', input: 'basic', expectedOutput: 'dev-basic'},
       {name: 'long', input: 'a'.repeat(100), expectedOutput: 'dev-aaaaaaaaaaaaaaaa'},
-      {name: 'special', input: 'some/feature_branch', expectedOutput: 'dev-some-feature-bra'},
+      {name: 'special', input: 'feature/new_function', expectedOutput: 'dev-ure-new-function'},
       {name: 'hyphen', input: '-name_-', expectedOutput: 'dev-name'},
     ];
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,12 @@
+const ENV_ID_LIMIT = 20; // Only 20 chars are supported
+
 export const branchNameToEnvId = (prefix: string, branchName: string): string => {
   branchName = branchName.replace(/[^a-z0-9-]+/g, '-'); // Remove unsupported chars
   branchName = branchName.replace(/^-+/, '').replace(/-+$/, ''); // Remove leading and trailing hyphens
 
-  return `${prefix}-${branchName}`.substring(0, 20); // Only 20 chars are supported
+
+  const idLimit = ENV_ID_LIMIT - `${prefix}-`.length;
+
+  // Return last as often common prefixes like "feat" or "dependabot" are used.
+  return `${prefix}-${branchName.slice(-idLimit)}`;
 };


### PR DESCRIPTION
Use the last chars of the branch name instead of the first to avoid name clashes with common prefixes like `dependabot/` or `feat/`