### PR TITLE
fix: double dash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,3 +23,10 @@ jobs:
       - run: npm run lint
       - run: npm test
       - run: npm run package
+      - name: Validate updated dist
+        run: |
+          if [ "$(git diff --ignore-space-at-eol --text dist/ | wc -l)" -gt "0" ]; then
+            echo "Changed dist found, please run \"npm run package\" locally and commit the changes."
+            git diff
+            exit 1
+          fi

--- a/dist/index.js
+++ b/dist/index.js
@@ -33490,8 +33490,10 @@ const branchNameToEnvId = (prefix, branchName) => {
     branchName = branchName.replace(/[^a-z0-9-]+/g, '-'); // Remove unsupported chars
     branchName = branchName.replace(/^-+/, '').replace(/-+$/, ''); // Remove leading and trailing hyphens
     const idLimit = ENV_ID_LIMIT - `${prefix}-`.length;
+    let suffix = branchName.slice(-idLimit);
+    suffix = suffix.replace(/^-+/, ''); // Remove leading hyphens to prevent -- in the env id
     // Return last as often common prefixes like "feat" or "dependabot" are used.
-    return `${prefix}-${branchName.slice(-idLimit)}`;
+    return `${prefix}-${suffix}`;
 };
 exports.branchNameToEnvId = branchNameToEnvId;
 

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -8,6 +8,7 @@ describe('utils', () => {
       {name: 'long', input: 'a'.repeat(100), expectedOutput: 'dev-aaaaaaaaaaaaaaaa'},
       {name: 'special', input: 'feature/new_function', expectedOutput: 'dev-ure-new-function'},
       {name: 'hyphen', input: '-name_-', expectedOutput: 'dev-name'},
+      {name: 'double-hyphen', input: 'skip-webhooks-webkit', expectedOutput: 'dev-webhooks-webkit'},
     ];
 
     for (const tc of testCases) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,9 +4,11 @@ export const branchNameToEnvId = (prefix: string, branchName: string): string =>
   branchName = branchName.replace(/[^a-z0-9-]+/g, '-'); // Remove unsupported chars
   branchName = branchName.replace(/^-+/, '').replace(/-+$/, ''); // Remove leading and trailing hyphens
 
-
   const idLimit = ENV_ID_LIMIT - `${prefix}-`.length;
 
+  let suffix = branchName.slice(-idLimit);
+  suffix = suffix.replace(/^-+/, ''); // Remove leading hyphens to prevent -- in the env id
+
   // Return last as often common prefixes like "feat" or "dependabot" are used.
-  return `${prefix}-${branchName.slice(-idLimit)}`;
+  return `${prefix}-${suffix}`;
 };


### PR DESCRIPTION
Fix double dash in environment name when the first char after the cut was a `-`.